### PR TITLE
shut down the delegate AmazonS3 instance

### DIFF
--- a/s3-decorators-core/src/main/java/com/hubspot/s3/S3Decorator.java
+++ b/s3-decorators-core/src/main/java/com/hubspot/s3/S3Decorator.java
@@ -1082,4 +1082,9 @@ public abstract class S3Decorator extends AbstractAmazonS3 {
   public PresignedUrlUploadResult upload(PresignedUrlUploadRequest presignedUrlUploadRequest) {
     return call(() -> getDelegate().upload(presignedUrlUploadRequest));
   }
+
+  @Override
+  public void shutdown() {
+    getDelegate().shutdown();
+  }
 }


### PR DESCRIPTION
Previously, this root S3Decorator object did not have an implementation
for shutdown, so it calling shutdown on it would fall through to the
AbstractAmazonS3#shutdown implementation. That implementation just
throws an UnsupportedOperationException, which fails to shutdown any
underlying resources and often results in the calling program crashing.

Adding this shutdown override lets clients close the delegate's
underlying resources